### PR TITLE
Terraform - include remote backend and verification pipeline

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -18,9 +18,6 @@ jobs:
       run:
         working-directory: .iac
 
-    environment:
-      name: apply-approval
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,17 +25,12 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
 
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
       - name: Terraform Init
         run: terraform init
+        env:
+          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
 
       - name: Terraform Plan
-        run: terraform plan -var "subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}"
-
-      - name: Terraform Apply
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: terraform apply -auto-approve -var "subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+        run: terraform plan"
+        env:
+          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}

--- a/.iac/main.tf
+++ b/.iac/main.tf
@@ -1,4 +1,12 @@
 terraform {
+    backend "remote" {
+    organization = "fund-devops-2025i"
+
+    workspaces {
+      name = "salus-infra-dev"
+    }
+  }
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -10,7 +18,6 @@ terraform {
 
 provider "azurerm" {
   features {}
-  subscription_id = var.subscription_id
 }
 
 resource "azurerm_resource_group" "salus" {

--- a/.iac/variables.tf
+++ b/.iac/variables.tf
@@ -1,8 +1,3 @@
-variable "subscription_id" {
-  description = "Azure Subscription ID"
-  type        = string
-}
-
 variable "resource_group_name" {
   description = "Nombre del resource group de Azure."
   type        = string


### PR DESCRIPTION
Este PR configura Terraform Cloud como backend remoto para manejar el estado de manera centralizada y segura. Se conectó el proyecto a una organización en Terraform Cloud y se ajustó la ruta de ejecución al directorio .iac.

También se actualizó el pipeline de GitHub Actions para autenticarse con Terraform Cloud. A futuro, se considera deprecar este pipeline y trabajar únicamente con la integración nativa de Terraform Cloud.